### PR TITLE
Feature/configurable routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cds-au/holder-sdk",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cds-au/holder-sdk",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@cds-au/holder-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "NodeJS middleware to handle error generation in line with Australian Consumer Data Standards technical specifications",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*.json",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/index.d.ts",
+    "dist/index.js"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "jest --coverage",

--- a/src/cdr-token-validator.ts
+++ b/src/cdr-token-validator.ts
@@ -16,7 +16,7 @@ export function cdrTokenValidator(authOptions: CdrConfig): any {
         let errorList : ResponseErrorListV2 = {
             errors:  []
         }
-        let ep = getEndpoint(req, authOptions.endpoints, errorList);
+        let ep = getEndpoint(req, authOptions, errorList);
         if (ep != null) {
             // if there no authorisation required
             if (ep.authScopesRequired == null) {

--- a/src/models/cdr-config.ts
+++ b/src/models/cdr-config.ts
@@ -1,5 +1,7 @@
 import { EndpointConfig } from "./endpoint-config";
 
 export interface  CdrConfig {
+    specifiedEndpointsOnly?: boolean;
+    basePath?: string;
     endpoints: EndpointConfig[];
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -69,7 +69,7 @@ describe('Utility functions', () => {
         }
 
         //req: Request, options: EndpointConfig[], errorList : ResponseErrorListV2 
-        let ep = getEndpoint(mockRequest as Request, options, errorList);
+        let ep = getEndpoint(mockRequest as Request, {endpoints: options}, errorList);
         expect(ep).not.toBeNull()
         expect(ep?.requestPath).toEqual('/energy/electricity/servicepoints');
     });
@@ -81,7 +81,7 @@ describe('Utility functions', () => {
             method: 'GET',
             url: `${standardsVersion}/banking/accounts/1234567`,
         }
-        let ep = getEndpoint(mockRequest as Request, options, errorList);
+        let ep = getEndpoint(mockRequest as Request, {endpoints: options}, errorList);
         expect(ep).not.toBeNull()
         expect(ep?.requestPath).toEqual('/banking/accounts/{accountId}');
 
@@ -94,7 +94,7 @@ describe('Utility functions', () => {
             method: 'GET',
             url: `${standardsVersion}/energy/accounts/123456/balance`,
         }
-        let ep = getEndpoint(mockRequest as Request, options, errorList);
+        let ep = getEndpoint(mockRequest as Request, {endpoints: options}, errorList);
         expect(ep).not.toBeNull();
         expect(ep?.requestPath).toEqual('/energy/accounts/{accountId}/balance');
 
@@ -107,7 +107,7 @@ describe('Utility functions', () => {
             method: 'GET',
             url: `${standardsVersion}/energy/accounts/123456/balance/`,
         }
-        let ep = getEndpoint(mockRequest as Request, options, errorList);
+        let ep = getEndpoint(mockRequest as Request, {endpoints: options}, errorList);
         expect(ep).not.toBeNull();
         expect(ep?.requestPath).toEqual('/energy/accounts/{accountId}/balance');
 
@@ -120,7 +120,7 @@ describe('Utility functions', () => {
             method: 'GET',
             url: `${standardsVersion}/energy/all-customer`,
         }
-        let ep = getEndpoint(mockRequest as Request, options, errorList);
+        let ep = getEndpoint(mockRequest as Request, {endpoints: options}, errorList);
         expect(ep).toBeUndefined();
 
     });
@@ -132,7 +132,7 @@ describe('Utility functions', () => {
             method: 'GET',
             url: `${standardsVersion}/banking/accounts/1234567?page=2&page-size=5`,
         }
-        let ep = getEndpoint(mockRequest as Request, options, errorList);
+        let ep = getEndpoint(mockRequest as Request, {endpoints: options}, errorList);
         expect(ep).not.toBeNull()
         expect(ep?.requestPath).toEqual('/banking/accounts/{accountId}');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
      "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
Added additional features in CdrConfig for certain scenarios:

1. Added a base path so that you can host endpoints at a location other than '/' (e.g. '/apis/cds-au/v1)
2. Added a flag that can be used to allow or disallow endpoints that are not explicitly mapped in config.  This allows for non-CDR endpoints to be hosted in the client app without getting the 'non-CDR' error message.  Useful for things like extension and health check endpoints